### PR TITLE
Refactor account clean architecture

### DIFF
--- a/core/src/main/java/com/rss/backend/account/api/controller/AuthController.java
+++ b/core/src/main/java/com/rss/backend/account/api/controller/AuthController.java
@@ -1,10 +1,10 @@
-package com.rss.backend.account.controller;
+package com.rss.backend.account.api.controller;
 
-import com.rss.backend.account.dto.AuthRequest;
-import com.rss.backend.account.dto.AuthResponse;
-import com.rss.backend.account.dto.RegisterDriverRequest;
-import com.rss.backend.account.dto.RegisterRiderRequest;
-import com.rss.backend.account.service.AuthService;
+import com.rss.backend.account.application.dto.AuthRequest;
+import com.rss.backend.account.application.dto.AuthResponse;
+import com.rss.backend.account.application.dto.RegisterDriverRequest;
+import com.rss.backend.account.application.dto.RegisterRiderRequest;
+import com.rss.backend.account.application.service.AuthService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/core/src/main/java/com/rss/backend/account/api/controller/DriverController.java
+++ b/core/src/main/java/com/rss/backend/account/api/controller/DriverController.java
@@ -1,7 +1,7 @@
-package com.rss.backend.account.controller;
+package com.rss.backend.account.api.controller;
 
-import com.rss.backend.account.entity.User;
-import com.rss.backend.account.repository.UserRepository;
+import com.rss.backend.account.domain.entity.User;
+import com.rss.backend.account.domain.repository.UserRepository;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,17 +9,24 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.stream.Stream;
+
 @RestController
-@RequestMapping("/api/rider")
+@RequestMapping("/api/driver")
 @RequiredArgsConstructor
 @SecurityRequirement(name = "Bearer Authentication")
-public class RiderController {
+public class DriverController {
     private final UserRepository userRepository;
 
     @GetMapping("/details/{userId}")
-    public String getRiderDetails(@PathVariable Long userId) {
+    public String getDriverDetails(@PathVariable Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
-        return "Rider: " + user.getUsername() + ", Payment Method: " + user.getRider().getDebt();
+        return "Driver: " + user.getUsername() + ", License: " + user.getDriver().getLicenseNumber();
+    }
+
+    @GetMapping("/allDetails/")
+    public Stream<String> getAllDriverDetails() {
+        return userRepository.findAll().stream().map(user -> "Driver: " + user.getUsername() + ", License: " + user.getDriver().getLicenseNumber());
     }
 }

--- a/core/src/main/java/com/rss/backend/account/api/controller/RiderController.java
+++ b/core/src/main/java/com/rss/backend/account/api/controller/RiderController.java
@@ -1,7 +1,7 @@
-package com.rss.backend.account.controller;
+package com.rss.backend.account.api.controller;
 
-import com.rss.backend.account.entity.User;
-import com.rss.backend.account.repository.UserRepository;
+import com.rss.backend.account.domain.entity.User;
+import com.rss.backend.account.domain.repository.UserRepository;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,24 +9,17 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.stream.Stream;
-
 @RestController
-@RequestMapping("/api/driver")
+@RequestMapping("/api/rider")
 @RequiredArgsConstructor
 @SecurityRequirement(name = "Bearer Authentication")
-public class DriverController {
+public class RiderController {
     private final UserRepository userRepository;
 
     @GetMapping("/details/{userId}")
-    public String getDriverDetails(@PathVariable Long userId) {
+    public String getRiderDetails(@PathVariable Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
-        return "Driver: " + user.getUsername() + ", License: " + user.getDriver().getLicenseNumber();
-    }
-
-    @GetMapping("/allDetails/")
-    public Stream<String> getAllDriverDetails() {
-        return userRepository.findAll().stream().map(user -> "Driver: " + user.getUsername() + ", License: " + user.getDriver().getLicenseNumber());
+        return "Rider: " + user.getUsername() + ", Payment Method: " + user.getRider().getDebt();
     }
 }

--- a/core/src/main/java/com/rss/backend/account/application/dto/AuthRequest.java
+++ b/core/src/main/java/com/rss/backend/account/application/dto/AuthRequest.java
@@ -1,6 +1,5 @@
-package com.rss.backend.account.dto;
+package com.rss.backend.account.application.dto;
 
-import com.rss.backend.account.entity.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,11 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class RegisterRiderRequest {
-    private String username;
+public class AuthRequest {
     private String email;
     private String password;
-    private Role role;
-
-    private String preferredPaymentMethod;
 }

--- a/core/src/main/java/com/rss/backend/account/application/dto/AuthResponse.java
+++ b/core/src/main/java/com/rss/backend/account/application/dto/AuthResponse.java
@@ -1,4 +1,4 @@
-package com.rss.backend.account.dto;
+package com.rss.backend.account.application.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/core/src/main/java/com/rss/backend/account/application/dto/RegisterDriverRequest.java
+++ b/core/src/main/java/com/rss/backend/account/application/dto/RegisterDriverRequest.java
@@ -1,4 +1,4 @@
-package com.rss.backend.account.dto;
+package com.rss.backend.account.application.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,7 +9,11 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class AuthRequest {
+public class RegisterDriverRequest {
+    private String username;
     private String email;
     private String password;
+
+    private String licenseNumber;
+    private String vehicleDetails;
 }

--- a/core/src/main/java/com/rss/backend/account/application/dto/RegisterRiderRequest.java
+++ b/core/src/main/java/com/rss/backend/account/application/dto/RegisterRiderRequest.java
@@ -1,5 +1,6 @@
-package com.rss.backend.account.dto;
+package com.rss.backend.account.application.dto;
 
+import com.rss.backend.account.domain.entity.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -9,11 +10,11 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class RegisterDriverRequest {
+public class RegisterRiderRequest {
     private String username;
     private String email;
     private String password;
+    private Role role;
 
-    private String licenseNumber;
-    private String vehicleDetails;
+    private String preferredPaymentMethod;
 }

--- a/core/src/main/java/com/rss/backend/account/application/port/out/JwtService.java
+++ b/core/src/main/java/com/rss/backend/account/application/port/out/JwtService.java
@@ -1,0 +1,17 @@
+package com.rss.backend.account.application.port.out;
+
+import io.jsonwebtoken.Claims;
+import java.util.Map;
+import java.util.function.Function;
+
+public interface JwtService {
+    String extractUsername(String token);
+
+    <T> T extractClaim(String token, Function<Claims, T> claimsResolver);
+
+    String generateToken(String username);
+
+    String generateToken(Map<String, Object> extraClaims, String username);
+
+    boolean isTokenValid(String token, String username);
+}

--- a/core/src/main/java/com/rss/backend/account/application/service/AuthService.java
+++ b/core/src/main/java/com/rss/backend/account/application/service/AuthService.java
@@ -1,16 +1,17 @@
-package com.rss.backend.account.service;
+package com.rss.backend.account.application.service;
 
-import com.rss.backend.account.dto.AuthRequest;
-import com.rss.backend.account.dto.AuthResponse;
-import com.rss.backend.account.dto.RegisterDriverRequest;
-import com.rss.backend.account.dto.RegisterRiderRequest;
-import com.rss.backend.account.entity.Role;
-import com.rss.backend.account.repository.DriverRepository;
-import com.rss.backend.account.repository.RiderRepository;
-import com.rss.backend.account.repository.UserRepository;
-import com.rss.backend.account.entity.Driver;
-import com.rss.backend.account.entity.Rider;
-import com.rss.backend.account.entity.User;
+import com.rss.backend.account.application.dto.AuthRequest;
+import com.rss.backend.account.application.dto.AuthResponse;
+import com.rss.backend.account.application.dto.RegisterDriverRequest;
+import com.rss.backend.account.application.dto.RegisterRiderRequest;
+import com.rss.backend.account.application.port.out.JwtService;
+import com.rss.backend.account.domain.entity.Role;
+import com.rss.backend.account.domain.repository.DriverRepository;
+import com.rss.backend.account.domain.repository.RiderRepository;
+import com.rss.backend.account.domain.repository.UserRepository;
+import com.rss.backend.account.domain.entity.Driver;
+import com.rss.backend.account.domain.entity.Rider;
+import com.rss.backend.account.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -47,7 +48,7 @@ public class AuthService {
         riderRepository.save(rider);
 
         // Generate JWT
-        var jwtToken = jwtService.generateToken(user);
+        var jwtToken = jwtService.generateToken(user.getEmail());
         return AuthResponse.builder()
                 .token(jwtToken)
                 .build();
@@ -75,7 +76,7 @@ public class AuthService {
         driverRepository.save(driver);
 
         // Generate JWT
-        var jwtToken = jwtService.generateToken(user);
+        var jwtToken = jwtService.generateToken(user.getEmail());
         return AuthResponse.builder()
                 .token(jwtToken)
                 .build();
@@ -90,7 +91,7 @@ public class AuthService {
         );
         var user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow();
-        var jwtToken = jwtService.generateToken(user);
+        var jwtToken = jwtService.generateToken(user.getEmail());
         return AuthResponse.builder()
                 .token(jwtToken)
                 .build();

--- a/core/src/main/java/com/rss/backend/account/config/UserPrincipal.java
+++ b/core/src/main/java/com/rss/backend/account/config/UserPrincipal.java
@@ -1,0 +1,42 @@
+package com.rss.backend.account.config;
+
+import com.rss.backend.account.entity.User;
+import java.util.Collection;
+import java.util.List;
+import lombok.Data;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Data
+public class UserPrincipal implements UserDetails {
+
+    private String email;
+    private String password;
+    private Long userId;
+    private Long riderId;
+    private Long driverId;
+    private String role;
+
+    public UserPrincipal(User user) {
+        this.userId = user.getId();
+        this.role = user.getRole().name();
+        this.email = user.getEmail();
+        this.password = user.getPassword();
+        if(role.equals("RIDER") && user.getRider() != null) {
+            this.riderId = user.getRider().getId();
+        } else if(role.equals("DRIVER") && user.getDriver() != null) {
+            this.driverId = user.getDriver().getId();
+        }
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(role));
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+}

--- a/core/src/main/java/com/rss/backend/account/controller/AuthController.java
+++ b/core/src/main/java/com/rss/backend/account/controller/AuthController.java
@@ -5,12 +5,14 @@ import com.rss.backend.account.dto.AuthResponse;
 import com.rss.backend.account.dto.RegisterDriverRequest;
 import com.rss.backend.account.dto.RegisterRiderRequest;
 import com.rss.backend.account.service.AuthService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
+@SecurityRequirements()
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;

--- a/core/src/main/java/com/rss/backend/account/domain/entity/Driver.java
+++ b/core/src/main/java/com/rss/backend/account/domain/entity/Driver.java
@@ -1,4 +1,4 @@
-package com.rss.backend.account.entity;
+package com.rss.backend.account.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -11,12 +11,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "riders")
-public class Rider {
+@Table(name = "drivers")
+public class Driver {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private Integer debt;
+
+    private String licenseNumber;
+    private String vehicleDetails;
+    private Integer credit;
+    private Integer rating;
+    private Integer rateCount;
 
     @OneToOne
     @JoinColumn(name = "user_id")

--- a/core/src/main/java/com/rss/backend/account/domain/entity/Rider.java
+++ b/core/src/main/java/com/rss/backend/account/domain/entity/Rider.java
@@ -1,4 +1,4 @@
-package com.rss.backend.account.entity;
+package com.rss.backend.account.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -11,17 +11,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
-@Table(name = "drivers")
-public class Driver {
+@Table(name = "riders")
+public class Rider {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    private String licenseNumber;
-    private String vehicleDetails;
-    private Integer credit;
-    private Integer rating;
-    private Integer rateCount;
+    private Integer debt;
 
     @OneToOne
     @JoinColumn(name = "user_id")

--- a/core/src/main/java/com/rss/backend/account/domain/entity/Role.java
+++ b/core/src/main/java/com/rss/backend/account/domain/entity/Role.java
@@ -1,0 +1,6 @@
+package com.rss.backend.account.domain.entity;
+
+public enum Role {
+    RIDER,
+    DRIVER
+}

--- a/core/src/main/java/com/rss/backend/account/domain/entity/User.java
+++ b/core/src/main/java/com/rss/backend/account/domain/entity/User.java
@@ -1,4 +1,4 @@
-package com.rss.backend.account.entity;
+package com.rss.backend.account.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/core/src/main/java/com/rss/backend/account/domain/repository/DriverRepository.java
+++ b/core/src/main/java/com/rss/backend/account/domain/repository/DriverRepository.java
@@ -1,6 +1,6 @@
-package com.rss.backend.account.repository;
+package com.rss.backend.account.domain.repository;
 
-import com.rss.backend.account.entity.Driver;
+import com.rss.backend.account.domain.entity.Driver;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DriverRepository extends JpaRepository<Driver, Long> {

--- a/core/src/main/java/com/rss/backend/account/domain/repository/RiderRepository.java
+++ b/core/src/main/java/com/rss/backend/account/domain/repository/RiderRepository.java
@@ -1,6 +1,6 @@
-package com.rss.backend.account.repository;
+package com.rss.backend.account.domain.repository;
 
-import com.rss.backend.account.entity.Rider;
+import com.rss.backend.account.domain.entity.Rider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RiderRepository extends JpaRepository<Rider, Long> {

--- a/core/src/main/java/com/rss/backend/account/domain/repository/UserRepository.java
+++ b/core/src/main/java/com/rss/backend/account/domain/repository/UserRepository.java
@@ -1,6 +1,6 @@
-package com.rss.backend.account.repository;
+package com.rss.backend.account.domain.repository;
 
-import com.rss.backend.account.entity.User;
+import com.rss.backend.account.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/core/src/main/java/com/rss/backend/account/entity/Role.java
+++ b/core/src/main/java/com/rss/backend/account/entity/Role.java
@@ -1,6 +1,0 @@
-package com.rss.backend.account.entity;
-
-public enum Role {
-    RIDER,
-    DRIVER
-}

--- a/core/src/main/java/com/rss/backend/account/entity/User.java
+++ b/core/src/main/java/com/rss/backend/account/entity/User.java
@@ -5,12 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.Collection;
-import java.util.List;
 
 @Data
 @Builder
@@ -18,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @Table(name = "users")
-public class User implements UserDetails {
+public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -35,34 +29,4 @@ public class User implements UserDetails {
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Driver driver;
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(role.name()));
-    }
-
-    @Override
-    public String getUsername() {
-        return email;
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
 }

--- a/core/src/main/java/com/rss/backend/account/infrastructure/security/JwtAuthFilter.java
+++ b/core/src/main/java/com/rss/backend/account/infrastructure/security/JwtAuthFilter.java
@@ -1,6 +1,6 @@
-package com.rss.backend.account.config;
+package com.rss.backend.account.infrastructure.security;
 
-import com.rss.backend.account.service.JwtService;
+import com.rss.backend.account.application.port.out.JwtService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,7 +44,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
 
-            if (jwtService.isTokenValid(jwt, userDetails)) {
+            if (jwtService.isTokenValid(jwt, userDetails.getUsername())) {
                 UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                         userDetails,
                         null,

--- a/core/src/main/java/com/rss/backend/account/infrastructure/security/SecurityConfig.java
+++ b/core/src/main/java/com/rss/backend/account/infrastructure/security/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.rss.backend.account.config;
+package com.rss.backend.account.infrastructure.security;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;

--- a/core/src/main/java/com/rss/backend/account/infrastructure/security/UserDetailsServiceImpl.java
+++ b/core/src/main/java/com/rss/backend/account/infrastructure/security/UserDetailsServiceImpl.java
@@ -1,8 +1,7 @@
-package com.rss.backend.account.service;
+package com.rss.backend.account.infrastructure.security;
 
-import com.rss.backend.account.config.UserPrincipal;
-import com.rss.backend.account.entity.User;
-import com.rss.backend.account.repository.UserRepository;
+import com.rss.backend.account.domain.entity.User;
+import com.rss.backend.account.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/core/src/main/java/com/rss/backend/account/infrastructure/security/UserPrincipal.java
+++ b/core/src/main/java/com/rss/backend/account/infrastructure/security/UserPrincipal.java
@@ -1,6 +1,6 @@
-package com.rss.backend.account.config;
+package com.rss.backend.account.infrastructure.security;
 
-import com.rss.backend.account.entity.User;
+import com.rss.backend.account.domain.entity.User;
 import java.util.Collection;
 import java.util.List;
 import lombok.Data;

--- a/core/src/main/java/com/rss/backend/account/service/UserDetailsServiceImpl.java
+++ b/core/src/main/java/com/rss/backend/account/service/UserDetailsServiceImpl.java
@@ -1,5 +1,7 @@
 package com.rss.backend.account.service;
 
+import com.rss.backend.account.config.UserPrincipal;
+import com.rss.backend.account.entity.User;
 import com.rss.backend.account.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -14,7 +16,8 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return userRepository.findByEmail(email)
+        User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return new UserPrincipal(user);
     }
 }

--- a/core/src/main/java/com/rss/backend/common/annotation/CurrentDriverId.java
+++ b/core/src/main/java/com/rss/backend/common/annotation/CurrentDriverId.java
@@ -1,0 +1,13 @@
+package com.rss.backend.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "driverId")
+public @interface CurrentDriverId {
+}

--- a/core/src/main/java/com/rss/backend/common/annotation/CurrentRiderId.java
+++ b/core/src/main/java/com/rss/backend/common/annotation/CurrentRiderId.java
@@ -1,0 +1,13 @@
+package com.rss.backend.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "riderId")
+public @interface CurrentRiderId {
+}

--- a/core/src/main/java/com/rss/backend/common/annotation/CurrentUserId.java
+++ b/core/src/main/java/com/rss/backend/common/annotation/CurrentUserId.java
@@ -1,0 +1,13 @@
+package com.rss.backend.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AuthenticationPrincipal(expression = "userId")
+public @interface CurrentUserId {
+}

--- a/core/src/main/java/com/rss/backend/common/config/SwaggerConfig.java
+++ b/core/src/main/java/com/rss/backend/common/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.rss.backend.account.config;
+package com.rss.backend.common.config;
 
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;

--- a/core/src/main/java/com/rss/backend/common/package-info.java
+++ b/core/src/main/java/com/rss/backend/common/package-info.java
@@ -1,0 +1,4 @@
+@org.springframework.modulith.ApplicationModule(
+        type = org.springframework.modulith.ApplicationModule.Type.OPEN
+)
+package com.rss.backend.common;

--- a/core/src/main/java/com/rss/backend/location/LocationController.java
+++ b/core/src/main/java/com/rss/backend/location/LocationController.java
@@ -1,5 +1,7 @@
 package com.rss.backend.location;
 
+import com.rss.backend.common.annotation.CurrentDriverId;
+import jakarta.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -9,29 +11,30 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/drivers/location")
+@RequestMapping("/api/drivers")
 @RequiredArgsConstructor
 public class LocationController {
     private final LocationService locationService;
 
-    @PostMapping(value = "/update")
-    public ResponseEntity<String> getRoute(
+    @PostMapping(value = "/location/update")
+    public ResponseEntity<String> updateDriverLocation(
             @RequestParam("x") Double x,
-            @RequestParam("y") Double y) {
-        locationService.updateDriverLocationInternal(x, y);
+            @RequestParam("y") Double y,
+            @NotNull @CurrentDriverId Long id) {
+        locationService.updateDriverLocationInternal(id, x, y);
         return ResponseEntity.ok("driver location updated.");
     }
 
-    @GetMapping
-    public ResponseEntity<?> getDriverLocationInternal(@RequestParam("username") String username) {
-        double[] coords = locationService.getDriverLocationInternal(username);
-        if (coords == null) {
+    @GetMapping("/{id}/location")
+    public ResponseEntity<?> getDriverLocationInternal(@PathVariable Long id) {
+        double[] location = locationService.getDriverLocationInternal(id);
+        if (location == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Driver location not found");
         }
         Map<String, Object> body = new HashMap<>();
-        body.put("username", username);
-        body.put("x", coords[0]);
-        body.put("y", coords[1]);
+        body.put("id", id);
+        body.put("x", location[0]);
+        body.put("y", location[1]);
         return ResponseEntity.ok(body);
     }
 
@@ -40,7 +43,7 @@ public class LocationController {
             @RequestParam("x") double x,
             @RequestParam("y") double y,
             @RequestParam("radius") double radiusUnits) {
-        Set<String> drivers = locationService.findDriversWithinRadiusInternal(x, y, radiusUnits);
+        Set<Long> drivers = locationService.findDriversWithinRadiusInternal(x, y, radiusUnits);
         Map<String, Object> body = new HashMap<>();
         body.put("centerX", x);
         body.put("centerY", y);

--- a/core/src/main/java/com/rss/backend/map/controller/MapController.java
+++ b/core/src/main/java/com/rss/backend/map/controller/MapController.java
@@ -1,6 +1,7 @@
 package com.rss.backend.map.controller;
 
 import com.rss.backend.map.service.MapService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Map;
 
 @RestController
+@SecurityRequirements()
 @RequestMapping("/api/map")
 @RequiredArgsConstructor
 public class MapController {


### PR DESCRIPTION
This pull request refactors the account module to improve package organization and clarify domain boundaries, while also updating JWT handling for increased consistency. The changes primarily move files into new packages (`domain`, `application`, `infrastructure`) and update JWT service usage to operate on usernames (emails) instead of `UserDetails`. Additionally, entity and repository classes are reorganized, and the JWT service is now accessed via an interface for better abstraction.

**Package and Layer Refactoring**
* Controllers, DTOs, entities, and repositories have been reorganized into `api`, `application`, `domain`, and `infrastructure` packages to better reflect their roles in the architecture. This includes renaming files and updating import paths throughout the codebase. [[1]](diffhunk://#diff-b8781c751d6f4b85bb5e1c4dd7fb7907a4774f89c86bab8f43e286f7e95c390aL1-R15) [[2]](diffhunk://#diff-b052f18fd8f73ce5b4cc9ad0b273dbfa01ef8c8a5c59a7acfe377892051bbc55L1-R4) [[3]](diffhunk://#diff-b47c712cf59ab6d630568194546c673b4090a0d1e9f494305503459a6c27b7f8L1-R4) [[4]](diffhunk://#diff-f0ee3a00b5d6e8f5697532755aa889e0960a69c60d97d630e1a87ceadd657f71L1-R1) [[5]](diffhunk://#diff-2efc2429be28bc5348b41e2b4d7c27e49e8ba2642e42e026dde16d9956cdb8e6L1-R1) [[6]](diffhunk://#diff-b8978c089d493881df5f293d9fc547491749a73d424e57f532b1a243c75cf9d1L1-R1) [[7]](diffhunk://#diff-b8344e69caa63d3f94a59bb0c9944da14f2e64584d0624e91e0f227f4fbe2900L1-R3) [[8]](diffhunk://#diff-f974e5a5e3fbc165d3d28a15740ee85030c76ca3a4ff612ba5d69f38d86d7671L1-R14) [[9]](diffhunk://#diff-ba80f04b03b4fe59593242df66dbdb9e7d4f2aabfd2883b5eb1dd8fb5f30e033L1-R1) [[10]](diffhunk://#diff-f94fbf1909516acf9f9bf179163c8390d8da56be372b2b5b546c90ba9a57bdb4L1-R1) [[11]](diffhunk://#diff-623a82562bfaf7fd40a69ebd08a283a29f795bd3ee429ca10ea367f28fdacf8aL1-R3) [[12]](diffhunk://#diff-59a56c9b7c6fb9fc396da02c82fa4416c90c104011aeb3cd8a871fa3fc7b2c06L1-R3) [[13]](diffhunk://#diff-331a9194fd276256d9d554e5603e10c6d2f88d547b7937af1cdded1c5be17a3cL1-R3) [[14]](diffhunk://#diff-5b75469d34febed3bb289b54c7d2f341fe184f20d20ea8c6a0e907f8cfe07716L1-R3) [[15]](diffhunk://#diff-0c06b817750d9618a7318138f1b269bd203d7c5c81b4d83c3e95754b50ef15abL1-L8) [[16]](diffhunk://#diff-03951ba2c4687efb3a6fa6898b6798be90b7601d999691b74f3c20ccc968e5baL1-R1)

**Domain Model Updates**
* The `Role` enum and `User` entity have been moved to the new `domain.entity` package. The old `User` entity implementation (which included `UserDetails`) was removed and replaced with a simpler version. [[1]](diffhunk://#diff-903445ac77bfb076697bba93aa0fb224076866b28eac81a2917a6984b8e6a139R1-R6) [[2]](diffhunk://#diff-2383ec80fbcce530de8dcc87a3daaec46f6273211a0b09bf844e629d31c941adR1-R32) [[3]](diffhunk://#diff-4945ff847f5dec60ecd0a842dd63f817cb638f612547f4cf03014c4e038864a7L1-L6) [[4]](diffhunk://#diff-7a3577d4d8c0720777fb16fed6efbbf4fd6890007ac54c0897ff172944307c43L1-L68)

**JWT Service Abstraction and Usage**
* The JWT service is now accessed via the `JwtService` interface, and its implementation (`JwtServiceImpl`) is moved to the `infrastructure.security` package. JWT token generation and validation now use `username` (email) instead of `UserDetails`, simplifying method signatures and usage. [[1]](diffhunk://#diff-f974e5a5e3fbc165d3d28a15740ee85030c76ca3a4ff612ba5d69f38d86d7671L1-R14) [[2]](diffhunk://#diff-5b75469d34febed3bb289b54c7d2f341fe184f20d20ea8c6a0e907f8cfe07716L47-R47) [[3]](diffhunk://#diff-0c06b817750d9618a7318138f1b269bd203d7c5c81b4d83c3e95754b50ef15abL18-R51)

**JWT Token Generation Changes**
* In the authentication and registration flows (`AuthService`), JWT tokens are generated using the user's email rather than the entire user object, aligning with the updated JWT service API. [[1]](diffhunk://#diff-f974e5a5e3fbc165d3d28a15740ee85030c76ca3a4ff612ba5d69f38d86d7671L50-R51) [[2]](diffhunk://#diff-f974e5a5e3fbc165d3d28a15740ee85030c76ca3a4ff612ba5d69f38d86d7671L78-R79) [[3]](diffhunk://#diff-f974e5a5e3fbc165d3d28a15740ee85030c76ca3a4ff612ba5d69f38d86d7671L93-R94)

**Repository Refactoring**
* All repository interfaces have been moved to the `domain.repository` package, and their entity references updated to match the new package structure. [[1]](diffhunk://#diff-623a82562bfaf7fd40a69ebd08a283a29f795bd3ee429ca10ea367f28fdacf8aL1-R3) [[2]](diffhunk://#diff-59a56c9b7c6fb9fc396da02c82fa4416c90c104011aeb3cd8a871fa3fc7b2c06L1-R3) [[3]](diffhunk://#diff-331a9194fd276256d9d554e5603e10c6d2f88d547b7937af1cdded1c5be17a3cL1-R3)

Let me know if you want more details on any part of this refactor!